### PR TITLE
Add `redirect_uri` parameter to authorization request

### DIFF
--- a/examples/oauth2/oauth2_chrome_test.py
+++ b/examples/oauth2/oauth2_chrome_test.py
@@ -16,7 +16,8 @@ def test_chrome():
         'oauth2_client_secret': os.environ['OAUTH2_CLIENT_SECRET'],
         'oauth2_authz_endpoint_url': os.environ['OAUTH2_AUTHZ_ENDPOINT_URL'],
         'oauth2_token_endpoint_url': os.environ['OAUTH2_TOKEN_ENDPOINT_URL'],
-        'scopes': os.environ['OAUTH2_SCOPES'],
+        'oauth2_redirect_uri': os.getenv('OAUTH2_REDIRECT_URI', ''),
+        'oauth2_scopes': os.environ['OAUTH2_SCOPES'],
         'http_request_method': os.getenv('HTTP_REQUEST_METHOD', 'GET'),
         'http_request_url': os.environ['HTTP_REQUEST_URL'],
     }

--- a/testdep/oauth2clientweb/main.go
+++ b/testdep/oauth2clientweb/main.go
@@ -205,6 +205,7 @@ func main() {
 		clientSecret := c.PostForm("oauth2_client_secret")
 		authzEndpointURL := c.PostForm("oauth2_authz_endpoint_url")
 		tokenEndpointURL := c.PostForm("oauth2_token_endpoint_url")
+		redirectURL := c.PostForm("oauth2_redirect_uri")
 		scopes := c.PostForm("oauth2_scopes")
 		tx := db.MustBegin()
 		tx.MustExec(
@@ -228,8 +229,6 @@ func main() {
 			return
 		}
 
-		//redirectURL := fmt.Sprintf("http://%s/authz/test/callback", c.Request.Header.Get("HOST"))
-
 		state := randToken()
 		session := sessions.Default(c)
 		session.Set("state", state)
@@ -238,7 +237,7 @@ func main() {
 		conf := &oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
-			//RedirectURL:  redirectURL,
+			RedirectURL:  redirectURL,
 			Scopes:       strings.Split(scopes, ","),
 			Endpoint: oauth2.Endpoint{
 				AuthURL:  authzEndpointURL,

--- a/testdep/oauth2clientweb/views/authz/test/new.html.tmpl
+++ b/testdep/oauth2clientweb/views/authz/test/new.html.tmpl
@@ -8,31 +8,35 @@
     <form class="ui form" action="/authz/test" method="post">
       <div class="field">
         <label>OAuth2 Client ID</label>
-         <input type="text" name="oauth2_client_id" placeholder="OAuth2 Client ID"></input>
+         <input type="text" id="oauth2_client_id" name="oauth2_client_id" placeholder="OAuth2 Client ID"></input>
       </div>
       <div class="field">
         <label>OAuth2 Client Secret</label>
-        <input type="text" name="oauth2_client_secret" placeholder="OAuth2 Client Secret"></input>
+        <input type="text" id="oauth2_client_secret" name="oauth2_client_secret" placeholder="OAuth2 Client Secret"></input>
       </div>
       <div class="field">
         <label>OAuth2 Authorization Endpoint URL</label>
-        <input type="text" name="oauth2_authz_endpoint_url" placeholder="OAuth2 Authorization Endpoint URL"></input>
+        <input type="text" id="oauth2_authz_endpoint_url" name="oauth2_authz_endpoint_url" placeholder="OAuth2 Authorization Endpoint URL"></input>
       </div>
       <div class="field">
         <label>OAuth2 Token Endpoint URL</label>
-        <input type="text" name="oauth2_token_endpoint_url" placeholder="OAuth2 Token Endpoint URL"></input>
+        <input type="text" id="oauth2_token_endpoint_url" name="oauth2_token_endpoint_url" placeholder="OAuth2 Token Endpoint URL"></input>
+      </div>
+      <div class="field">
+        <label>OAuth2 Redirect URI</label>
+        <input type="text" id="oauth2_redirect_uri" name="oauth2_redirect_uri" placeholder="OAuth2 Redirect URI"></input>
       </div>
       <div class="field">
         <label>OAuth2 Scopes</label>
-        <input type="text" name="scopes" placeholder="OAuth2 Scopes"></input>
+        <input type="text" id="oauth2_scopes" name="oauth2_scopes" placeholder="OAuth2 Scopes"></input>
       </div>
       <div class="field">
         <label>Assertion HTTP Request Method</label>
-        <input type="text" name="http_request_method" placeholder="Assertion HTTP Request Method"></input>
+        <input type="text" id="http_request_method" name="http_request_method" placeholder="Assertion HTTP Request Method"></input>
       </div>
       <div class="field">
         <label>Assertion HTTP Request URL</label>
-        <input type="text" name="http_request_url" placeholder="Assertion HTTP Request URL"></input>
+        <input type="text" id="http_request_url" name="http_request_url" placeholder="Assertion HTTP Request URL"></input>
       </div>
       <button class="ui button" type="submit">Submit</button>
     </form>


### PR DESCRIPTION
### Purpose

Add `redirect_uri` form element to pass its value to authorization server.

### Additional impl and fix

 - Add id to each to input elements for id_selector (https://github.com/mumoshu/kube-distributed-test-runner/blob/828583f136a382c037f417e725830eea26303f78/examples/oauth2/oauth2_chrome_test.py#L25)
 - Fix scopes element name (https://github.com/mumoshu/kube-distributed-test-runner/blob/828583f136a382c037f417e725830eea26303f78/testdep/oauth2clientweb/main.go#L208)

